### PR TITLE
解决签到失败的问题

### DIFF
--- a/hifini.py
+++ b/hifini.py
@@ -5,7 +5,8 @@ new Env('HiFiNi');
 """
 
 import json
-from sendNotify import send
+# from sendNotify import send  # 本地调试用
+from notify import send  # 导入青龙后自动有这个文件
 from bs4 import BeautifulSoup
 import requests
 import re

--- a/hifini.py
+++ b/hifini.py
@@ -16,7 +16,7 @@ requests.packages.urllib3.disable_warnings()
 
 
 def start(cookie):
-    max_retries = 20
+    max_retries = 5
     retries = 0
     msg = ""
     while retries < max_retries:


### PR DESCRIPTION
- 修改了请求的header
- 根据网页签到信息，将请求方法改为get
- 为了方便解析，使用了BeautifulSoup，需要在说明文档中提醒用户安装相关依赖（pip install beautifulsoup4，文档里我还没更改）
- 降低了请求重试的次数，改为了5，防止多次请求导致账号被封
- 改用青龙面板自带的 notify 进行通知